### PR TITLE
WDP220201-5

### DIFF
--- a/src/components/common/ProductBox/ProductBox.js
+++ b/src/components/common/ProductBox/ProductBox.js
@@ -11,7 +11,7 @@ import {
 import { faStar as farStar, faHeart } from '@fortawesome/free-regular-svg-icons';
 import Button from '../Button/Button';
 
-const ProductBox = ({ name, price, promo, stars }) => (
+const ProductBox = ({ name, price, promo, stars, ...props }) => (
   <div className={styles.root}>
     <div className={styles.photo}>
       {promo && <div className={styles.sale}>{promo}</div>}
@@ -39,11 +39,24 @@ const ProductBox = ({ name, price, promo, stars }) => (
     <div className={styles.line}></div>
     <div className={styles.actions}>
       <div className={styles.outlines}>
-        <Button variant='outline'>
-          <FontAwesomeIcon icon={faHeart}>Favorite</FontAwesomeIcon>
+        <Button variant='outline' className={props.favorite && styles.btnActive}>
+          <FontAwesomeIcon
+            icon={faHeart}
+            className={props.favorite && styles.iconActive}
+          >
+            Favorite
+          </FontAwesomeIcon>
         </Button>
-        <Button variant='outline'>
-          <FontAwesomeIcon icon={faExchangeAlt}>Add to compare</FontAwesomeIcon>
+        <Button
+          variant='outline'
+          className={props.addedForComparison && styles.btnActive}
+        >
+          <FontAwesomeIcon
+            icon={faExchangeAlt}
+            className={props.addedForComparison && styles.iconActive}
+          >
+            Add to compare
+          </FontAwesomeIcon>
         </Button>
       </div>
       <div className={styles.price}>
@@ -61,6 +74,8 @@ ProductBox.propTypes = {
   price: PropTypes.number,
   promo: PropTypes.string,
   stars: PropTypes.number,
+  favorite: PropTypes.bool,
+  addedForComparison: PropTypes.bool,
 };
 
 export default ProductBox;

--- a/src/components/common/ProductBox/ProductBox.module.scss
+++ b/src/components/common/ProductBox/ProductBox.module.scss
@@ -74,5 +74,13 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+
+    .btnActive {
+      background-color: $primary;
+    }
+
+    .iconActive {
+      color: white;
+    }
   }
 }

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -15,6 +15,7 @@ const initialState = {
       stars: 2,
       promo: 'sale',
       newFurniture: true,
+      favorite: true,
     },
     {
       id: 'aenean-ru-bristique-2',
@@ -24,6 +25,8 @@ const initialState = {
       stars: 2,
       promo: 'sale',
       newFurniture: true,
+      favorite: true,
+      addedForComparison: true,
     },
     {
       id: 'aenean-ru-bristique-3',
@@ -33,6 +36,7 @@ const initialState = {
       stars: 2,
       promo: 'sale',
       newFurniture: true,
+      addedForComparison: true,
     },
     {
       id: 'aenean-ru-bristique-4',


### PR DESCRIPTION
@PatrykBula 
**Rozwiązanie:**
w initialState pierwsze kilka produktów otrzymały opcjonalne właściwości "favorite" oraz "addedForComparison".
W zależności od obecności tych że propsów w komponencie ProductBox buttony otrzymują opcjonalną klasę active (style: bgColor buttonu: kremowy, kolor ikony: biały).
Docelowo chyba będą osobne subreducery do zarządzania wybranymi produktami.
**Opis:**
Brak ostylowanych stanów "ulubiony" oraz "dodany do porównania".
Po otwarciu strony ma być co najmniej po jednym produkcie, który ma aktywne: 
żaden z tych buttonów
tylko "ulubiony"
tylko "dodany do porównania"
oba buttony
