### PR TITLE
Add RWD to DealsBox

### DIFF
--- a/src/components/features/DealsBox/DealsBox.js
+++ b/src/components/features/DealsBox/DealsBox.js
@@ -14,7 +14,7 @@ const DealsBox = () => {
     <div className={styles.root}>
       <div className='container'>
         <div className='row'>
-          <div className='col-6'>
+          <div className='col-xs-12 col-sm-6'>
             <div className={styles.bannerLarge}>
               <img
                 alt='sofa'
@@ -27,7 +27,10 @@ const DealsBox = () => {
               </div>
             </div>
           </div>
-          <div div className='col-6 d-flex flex-column justify-content-between'>
+          <div
+            div
+            className='col-xs-12 col-sm-6 d-flex flex-column justify-content-between'
+          >
             <div className={styles.bannerSmallTop}>
               <img
                 alt='sofa'

--- a/src/components/features/DealsBox/DealsBox.module.scss
+++ b/src/components/features/DealsBox/DealsBox.module.scss
@@ -166,6 +166,7 @@
           font-size: 40px;
         }
       }
+      margin-bottom: 10px;
     }
     .bannerSmallTop {
       .description {
@@ -173,6 +174,7 @@
           font-size: 18px;
         }
       }
+      margin-bottom: 10px;
     }
     .bannerSmallBottom {
       .description {


### PR DESCRIPTION
_Zadaniem jest stworzenie wersji mobilnych sekcji "Promocje". Klient nie ma designów RWD, więc trzeba zrobić na własną rękę. Na szerokościach, gdzie trzy boxy nie mieszczą się obok siebie, należy ułożyć je jeden pod drugim (największy na górze, pod nim dwa mniejsze)._

RWD dodałam przy okazji innego taska więc tuaj tylko mały tweak. 